### PR TITLE
feat: Replace landing page with dashboard layout (BAC-107)

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,11 +1,21 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import apiClient from "$lib/api";
-  import type { components } from "$lib/api/client";
+  import OrganizationDropdown from "$lib/components/OrganizationDropdown.svelte";
+  import TabNavigation from "$lib/components/TabNavigation.svelte";
+  import type { TabType, Organization, OrganizationWithProposals, Tab } from "$lib/types/dashboard.js";
 
-  let organizationsWithProposals: any[] = $state([]);
+  let organizationsWithProposals: OrganizationWithProposals[] = $state([]);
   let loading = $state(true);
   let error: string | null = $state(null);
+  let activeTab: TabType = $state('overview');
+  let selectedOrganization: Organization | null = $state(null);
+
+  const tabs: Tab[] = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'proposals', label: 'Proposals' },
+    { id: 'activity', label: 'Activity' }
+  ];
 
   const loadOrganizations = async () => {
     console.log("Loading organizations");
@@ -16,8 +26,11 @@
         ? String((apiError as any).message)
         : "Failed to load organizations";
     } else if (data) {
-      // Store the full data structure including proposals
       organizationsWithProposals = data.organizations;
+      // Set first organization as default if none selected
+      if (organizationsWithProposals.length > 0 && !selectedOrganization) {
+        selectedOrganization = organizationsWithProposals[0].organization;
+      }
     }
     loading = false;
   };
@@ -31,30 +44,56 @@
     }
   });
 
+  const handleTabChange = (tabId: TabType) => {
+    activeTab = tabId;
+  };
+
+  const handleOrganizationChange = (organization: Organization) => {
+    selectedOrganization = organization;
+  };
+
   const handleOrganizationClick = (orgId: string) => {
     goto(`/organizations/${orgId}`);
   };
+
+  // Get current organization data
+  const currentOrgData = $derived(selectedOrganization 
+    ? organizationsWithProposals.find(org => org.organization.id === selectedOrganization?.id)
+    : null);
+
+  // Get organizations list for dropdown
+  const organizations = $derived(organizationsWithProposals.map(org => org.organization));
 </script>
 
 <svelte:head>
-  <title>Quorum AI - DAO Organizations</title>
-  <meta name="description" content="Explore and manage decentralized autonomous organizations" />
+  <title>Dashboard - Quorum AI</title>
+  <meta name="description" content="DAO governance dashboard with proposals, activity, and analytics" />
 </svelte:head>
 
 <div class="space-y-6">
-  <!-- Header Section -->
-  <div class="text-center">
-    <h1 class="text-3xl font-bold text-secondary-900 mb-2">DAO Organizations</h1>
-    <p class="text-secondary-600 max-w-2xl mx-auto">
-      Discover and participate in decentralized autonomous organizations. View proposals, cast votes, and shape the future of decentralized governance.
-    </p>
+  <!-- Dashboard Header -->
+  <div class="flex items-center justify-between">
+    <h1 class="text-3xl font-bold text-secondary-900">Dashboard</h1>
+    
+    <!-- Organization Dropdown -->
+    <div class="flex items-center">
+      {#if !loading && organizations.length > 0}
+        <OrganizationDropdown 
+          {organizations}
+          {selectedOrganization}
+          onOrganizationChange={handleOrganizationChange}
+        />
+      {:else if loading}
+        <div class="animate-pulse bg-secondary-200 h-10 w-64 rounded-md"></div>
+      {/if}
+    </div>
   </div>
 
   <!-- Loading State -->
   {#if loading}
     <div class="flex justify-center items-center py-12">
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
-      <span class="ml-3 text-secondary-600">Loading organizations...</span>
+      <span class="ml-3 text-secondary-600">Loading dashboard...</span>
     </div>
   
   <!-- Error State -->
@@ -67,86 +106,209 @@
           </svg>
         </div>
         <div class="ml-3">
-          <h3 class="text-sm font-medium text-red-800">Failed to load organizations</h3>
+          <h3 class="text-sm font-medium text-red-800">Failed to load dashboard</h3>
           <p class="text-sm text-red-700 mt-1">{error}</p>
         </div>
       </div>
     </div>
   
-  <!-- Organizations Grid -->
+  <!-- Dashboard Content -->
   {:else}
-    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {#each organizationsWithProposals as orgData}
-        {@const org = orgData.organization}
-        <div 
-          class="card hover:shadow-md transition-shadow duration-200 cursor-pointer group"
-          onclick={() => handleOrganizationClick(org.id)}
-          onkeydown={(e) => e.key === 'Enter' && handleOrganizationClick(org.id)}
-          role="button"
-          tabindex="0"
-          aria-label="View {org.name} organization details"
-        >
-          <div class="flex items-start justify-between">
-            <div class="flex-1">
-              <h3 class="text-lg font-semibold text-secondary-900 group-hover:text-primary-600 transition-colors duration-200">
-                {org.name}
-              </h3>
-              {#if org.slug}
-                <p class="text-secondary-600 text-sm mt-1">
-                  @{org.slug}
-                </p>
+    <!-- Tab Navigation -->
+    <TabNavigation 
+      {tabs}
+      {activeTab}
+      onTabChange={handleTabChange}
+    />
+
+    <!-- Tab Content -->
+    <div class="mt-6">
+      {#if activeTab === 'overview'}
+        <div id="tab-panel-overview" role="tabpanel" aria-labelledby="tab-overview">
+          {#if currentOrgData}
+            {@const org = currentOrgData.organization}
+            <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              <!-- Organization Overview Card -->
+              <div class="card">
+                <div class="flex items-start justify-between">
+                  <div class="flex-1">
+                    <h3 class="text-lg font-semibold text-secondary-900">
+                      {org.name}
+                    </h3>
+                    {#if org.slug}
+                      <p class="text-secondary-600 text-sm mt-1">
+                        @{org.slug}
+                      </p>
+                    {/if}
+                  </div>
+                  <button
+                    class="ml-4 flex-shrink-0 text-primary-600 hover:text-primary-700"
+                    onclick={() => handleOrganizationClick(org.id)}
+                    aria-label="View {org.name} details"
+                  >
+                    <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                </div>
+                
+                <div class="mt-4 grid grid-cols-2 gap-4 text-sm">
+                  <div class="flex items-center">
+                    <svg class="h-4 w-4 mr-2 text-secondary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                    <span class="text-secondary-600">{org.proposals_count} proposals</span>
+                  </div>
+                  {#if org.chain_ids && org.chain_ids.length > 0}
+                    <div class="flex items-center">
+                      <svg class="h-4 w-4 mr-2 text-secondary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                      </svg>
+                      <span class="text-secondary-600">{org.chain_ids?.length || 0} {(org.chain_ids?.length || 0) === 1 ? 'chain' : 'chains'}</span>
+                    </div>
+                  {/if}
+                  <div class="flex items-center">
+                    <svg class="h-4 w-4 mr-2 text-secondary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197m13.5-9a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0z" />
+                    </svg>
+                    <span class="text-secondary-600">{org.delegates_count.toLocaleString()} delegates</span>
+                  </div>
+                  <div class="flex items-center">
+                    <svg class="h-4 w-4 mr-2 text-secondary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                    </svg>
+                    <span class="text-secondary-600">{org.token_owners_count.toLocaleString()} token holders</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Recent Proposals -->
+              {#if currentOrgData.proposals && currentOrgData.proposals.length > 0}
+                <div class="card lg:col-span-2">
+                  <h4 class="text-lg font-semibold text-secondary-900 mb-4">Recent Proposals</h4>
+                  <div class="space-y-4">
+                    {#each currentOrgData.proposals.slice(0, 3) as proposal}
+                      <div class="border-b border-secondary-200 pb-4 last:border-b-0 last:pb-0">
+                        <div class="flex items-start justify-between">
+                          <div class="flex-1">
+                            <h5 class="font-medium text-secondary-900">{proposal.title}</h5>
+                            <p class="text-sm text-secondary-600 mt-1">{proposal.summary}</p>
+                            <div class="flex items-center gap-2 mt-2">
+                              <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium
+                                {proposal.risk_level === 'LOW' ? 'bg-green-100 text-green-800' : 
+                                 proposal.risk_level === 'MEDIUM' ? 'bg-yellow-100 text-yellow-800' : 
+                                 'bg-red-100 text-red-800'}">
+                                {proposal.risk_level}
+                              </span>
+                              <span class="text-secondary-400">•</span>
+                              <span class="text-sm text-secondary-600">{proposal.recommendation}</span>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    {/each}
+                  </div>
+                </div>
               {/if}
             </div>
-            <div class="ml-4 flex-shrink-0">
-              <svg class="h-5 w-5 text-secondary-400 group-hover:text-primary-500 transition-colors duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+          {:else}
+            <div class="text-center py-12">
+              <svg class="mx-auto h-12 w-12 text-secondary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
               </svg>
-            </div>
-          </div>
-          
-          <div class="mt-4 flex items-center justify-between text-sm text-secondary-500">
-            <div class="flex items-center">
-              <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-              </svg>
-              {org.proposals_count} proposals
-            </div>
-            {#if org.chain_ids && org.chain_ids.length > 0}
-              <div class="flex items-center">
-                <svg class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                </svg>
-                {org.chain_ids.length} {org.chain_ids.length === 1 ? 'chain' : 'chains'}
-              </div>
-            {/if}
-          </div>
-
-          <!-- Show AI-summarized proposals -->
-          {#if orgData.proposals && orgData.proposals.length > 0}
-            <div class="mt-4 border-t pt-4">
-              <h4 class="text-sm font-medium text-secondary-700 mb-2">Recent Proposals</h4>
-              <div class="space-y-2">
-                {#each orgData.proposals.slice(0, 2) as proposal}
-                  <div class="text-xs text-secondary-600">
-                    <div class="font-medium">{proposal.title}</div>
-                    <div class="text-secondary-500 mt-1">{proposal.summary}</div>
-                    <div class="flex items-center gap-2 mt-1">
-                      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
-                        {proposal.risk_level === 'LOW' ? 'bg-green-100 text-green-800' : 
-                         proposal.risk_level === 'MEDIUM' ? 'bg-yellow-100 text-yellow-800' : 
-                         'bg-red-100 text-red-800'}">
-                        {proposal.risk_level}
-                      </span>
-                      <span class="text-secondary-400">•</span>
-                      <span class="text-secondary-500">{proposal.recommendation}</span>
-                    </div>
-                  </div>
-                {/each}
-              </div>
+              <h3 class="mt-2 text-sm font-medium text-secondary-900">No organization selected</h3>
+              <p class="mt-1 text-sm text-secondary-500">Choose an organization from the dropdown to view its overview.</p>
             </div>
           {/if}
         </div>
-      {/each}
+      
+      {:else if activeTab === 'proposals'}
+        <div id="tab-panel-proposals" role="tabpanel" aria-labelledby="tab-proposals">
+          {#if currentOrgData}
+            <div class="card">
+              <h3 class="text-lg font-semibold text-secondary-900 mb-4">
+                All Proposals for {currentOrgData.organization.name}
+              </h3>
+              {#if currentOrgData.proposals && currentOrgData.proposals.length > 0}
+                <div class="space-y-4">
+                  {#each currentOrgData.proposals as proposal}
+                    <div class="border border-secondary-200 rounded-lg p-4 hover:border-primary-300 transition-colors duration-200">
+                      <div class="flex items-start justify-between">
+                        <div class="flex-1">
+                          <h4 class="font-medium text-secondary-900">{proposal.title}</h4>
+                          <p class="text-sm text-secondary-600 mt-2">{proposal.summary}</p>
+                          
+                          {#if proposal.key_points && proposal.key_points.length > 0}
+                            <div class="mt-3">
+                              <h5 class="text-xs font-medium text-secondary-700 mb-1">Key Points:</h5>
+                              <ul class="text-xs text-secondary-600 space-y-1">
+                                {#each proposal.key_points as point}
+                                  <li class="flex items-start">
+                                    <span class="text-primary-400 mr-1">•</span>
+                                    {point}
+                                  </li>
+                                {/each}
+                              </ul>
+                            </div>
+                          {/if}
+                          
+                          <div class="flex items-center gap-3 mt-3">
+                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium
+                              {proposal.risk_level === 'LOW' ? 'bg-green-100 text-green-800' : 
+                               proposal.risk_level === 'MEDIUM' ? 'bg-yellow-100 text-yellow-800' : 
+                               'bg-red-100 text-red-800'}">
+                              {proposal.risk_level} Risk
+                            </span>
+                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium
+                              {proposal.recommendation === 'APPROVE' ? 'bg-green-100 text-green-800' : 
+                               proposal.recommendation === 'REJECT' ? 'bg-red-100 text-red-800' : 
+                               'bg-gray-100 text-gray-800'}">
+                              {proposal.recommendation}
+                            </span>
+                            <span class="text-xs text-secondary-500">
+                              Confidence: {Math.round(proposal.confidence_score * 100)}%
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  {/each}
+                </div>
+              {:else}
+                <div class="text-center py-8">
+                  <svg class="mx-auto h-8 w-8 text-secondary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  <p class="mt-2 text-sm text-secondary-500">No proposals available for this organization.</p>
+                </div>
+              {/if}
+            </div>
+          {:else}
+            <div class="text-center py-12">
+              <svg class="mx-auto h-12 w-12 text-secondary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <h3 class="mt-2 text-sm font-medium text-secondary-900">No organization selected</h3>
+              <p class="mt-1 text-sm text-secondary-500">Choose an organization from the dropdown to view its proposals.</p>
+            </div>
+          {/if}
+        </div>
+      
+      {:else if activeTab === 'activity'}
+        <div id="tab-panel-activity" role="tabpanel" aria-labelledby="tab-activity">
+          <div class="card">
+            <div class="text-center py-12">
+              <svg class="mx-auto h-12 w-12 text-secondary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2a2 2 0 00-2 2v6a2 2 0 01-2 2H9a2 2 0 01-2-2v-6a2 2 0 00-2-2H5a2 2 0 01-2-2V5a2 2 0 012-2h2a2 2 0 012 2v4a2 2 0 01-2 2h-2z" />
+              </svg>
+              <h3 class="mt-2 text-sm font-medium text-secondary-900">Activity Feed Coming Soon</h3>
+              <p class="mt-1 text-sm text-secondary-500">
+                We're working on bringing you real-time activity feeds for DAO governance events.
+              </p>
+            </div>
+          </div>
+        </div>
+      {/if}
     </div>
   {/if}
 </div>

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,7 +4,7 @@ import { sveltekit } from '@sveltejs/kit/vite';
 export default defineConfig({
   plugins: [sveltekit()],
   test: {
-    environment: 'happy-dom',
+    environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
     globals: true
   }


### PR DESCRIPTION
## PR Type

- feature

## Summary

| File Name | Change Summary |
| --- | --- |
| frontend/src/routes/+page.svelte | Complete replacement of DAO organizations landing page with interactive dashboard featuring tabbed navigation, organization dropdown, and comprehensive proposal display |
| frontend/vitest.config.ts | Updated test environment from happy-dom to jsdom for better Svelte 5 compatibility |

## Linear Tickets

- [BAC-107: Frontend: Replace Landing Page with Dashboard Layout](https://linear.app/backland-labs/issue/BAC-107/frontend-replace-landing-page-with-dashboard-layout)

## Breaking Changes

- No breaking changes

## Edge Cases for Reviewer

- No edge cases found

## Reviewer Test Plan

- [ ] Verify Dashboard title displays correctly instead of "DAO Organizations"
- [ ] Test all three tabs (Overview, Proposals, Activity) switch properly and show correct content
- [ ] Confirm organization dropdown populates with available organizations from API
- [ ] Verify selected tab persists when switching between organizations
- [ ] Test responsive design by resizing browser window
- [ ] Confirm organization data displays correctly in Overview tab (proposals count, delegates, etc.)
- [ ] Verify Proposals tab shows detailed proposal information with risk levels and recommendations
- [ ] Check Activity tab shows "Coming Soon" placeholder
- [ ] Test that clicking organization name/arrow navigates to organization detail page
- [ ] Verify loading states display correctly while fetching data
- [ ] Test error handling if API request fails
- [ ] Confirm TypeScript compilation succeeds: `npm run check`
- [ ] Verify build succeeds: `npm run build`

🤖 Generated with [Claude Code](https://claude.ai/code)