### PR TITLE
feat: Update proposal fetching for specific DAOs with governor IDs (BAC-146)

### DIFF
--- a/backend/services/tally_service.py
+++ b/backend/services/tally_service.py
@@ -1079,3 +1079,20 @@ class TallyService:
                 error=str(e),
             )
             return False
+
+    async def get_proposals_by_governor_ids(
+        self, governor_ids: List[str], limit: int = 50
+    ) -> List[Proposal]:
+        """Fetch proposals for specific governor IDs."""
+        assert governor_ids, "Governor IDs list cannot be empty"
+        assert all(isinstance(gid, str) for gid in governor_ids), "All governor IDs must be strings"
+        assert limit > 0, "Limit must be positive"
+
+        if len(governor_ids) == 1:
+            # Single governor ID case - use existing get_proposals method
+            filters = ProposalFilters(dao_id=governor_ids[0], limit=limit)
+            proposals, _ = await self.get_proposals(filters)
+            return proposals
+
+        # Multiple governor IDs case - will be implemented in next iteration
+        return []

--- a/backend/services/tally_service.py
+++ b/backend/services/tally_service.py
@@ -1140,3 +1140,21 @@ class TallyService:
                     deduplicated_count=len(deduplicated))
         
         return deduplicated
+
+    async def get_proposals_by_organization_governors(
+        self, organization_id: str, limit: int = 50
+    ) -> List[Proposal]:
+        """Fetch proposals for all governors in an organization."""
+        assert organization_id, "Organization ID cannot be empty"
+        assert isinstance(organization_id, str), "Organization ID must be a string"
+        assert limit > 0, "Limit must be positive"
+
+        try:
+            # Use existing get_proposals method with organization filter
+            filters = ProposalFilters(organization_id=organization_id, limit=limit)
+            proposals, _ = await self.get_proposals(filters)
+            return proposals
+        except Exception as e:
+            logfire.error("Failed to fetch proposals by organization governors", 
+                         organization_id=organization_id, error=str(e))
+            raise

--- a/backend/services/tally_service.py
+++ b/backend/services/tally_service.py
@@ -1159,16 +1159,26 @@ class TallyService:
         return deduplicated
 
     async def get_proposals_by_organization_governors(
-        self, organization_id: str, limit: int = 50
+        self, organization_id: str, limit: int = 50, active_only: bool = False
     ) -> List[Proposal]:
-        """Fetch proposals for all governors in an organization."""
+        """Fetch proposals for all governors in an organization.
+        
+        Args:
+            organization_id: Organization ID to fetch proposals from
+            limit: Maximum number of proposals to fetch
+            active_only: If True, only fetch proposals in ACTIVE state
+        """
         assert organization_id, "Organization ID cannot be empty"
         assert isinstance(organization_id, str), "Organization ID must be a string"
         assert limit > 0, "Limit must be positive"
 
         try:
             # Use existing get_proposals method with organization filter
-            filters = ProposalFilters(organization_id=organization_id, limit=limit)
+            filters = ProposalFilters(
+                organization_id=organization_id, 
+                limit=limit,
+                state=ProposalState.ACTIVE if active_only else None
+            )
             proposals, _ = await self.get_proposals(filters)
             return proposals
         except Exception as e:

--- a/backend/services/tally_service.py
+++ b/backend/services/tally_service.py
@@ -1116,8 +1116,27 @@ class TallyService:
                     # Log error but continue with other results
                     logfire.error("Failed to fetch proposals for governor", error=str(result))
 
-            return all_proposals
+            # Deduplicate proposals by ID
+            return self._deduplicate_proposals(all_proposals)
         except Exception as e:
             logfire.error("Failed to fetch proposals by governor IDs", 
                          governor_ids=governor_ids, error=str(e))
             raise
+
+    def _deduplicate_proposals(self, proposals: List[Proposal]) -> List[Proposal]:
+        """Deduplicate proposals by ID, keeping the first occurrence."""
+        assert proposals is not None, "Proposals list cannot be None"
+        
+        seen_ids = set()
+        deduplicated = []
+        
+        for proposal in proposals:
+            if proposal.id not in seen_ids:
+                seen_ids.add(proposal.id)
+                deduplicated.append(proposal)
+        
+        logfire.info("Deduplicated proposals", 
+                    original_count=len(proposals), 
+                    deduplicated_count=len(deduplicated))
+        
+        return deduplicated


### PR DESCRIPTION
## PR Type

- feature

## Summary

This PR implements the complete BAC-146 feature for fetching proposals from specific DAOs using governor IDs, addressing the Tally API limitation that doesn't support filtering by multiple governor IDs in a single query.

| File Name | Change Summary |
| --- | --- |
| backend/services/tally_service.py | Added 3 new methods for governor-based proposal fetching: get_proposals_by_governor_ids(), get_proposals_by_organization_governors(), and _deduplicate_proposals(). Enhanced _build_filter_input() to support state filtering. Added comprehensive refactoring with helper methods, constants, and performance safeguards. |
| backend/tests/test_tally_service.py | Added 12 comprehensive test cases covering single/multiple governor IDs, deduplication, error handling, partial failures, and active proposal filtering functionality. |

## Linear Tickets

- [BAC-146: Update proposal fetching for specific DAOs with governor IDs](https://linear.app/backland-labs/issue/BAC-146/update-proposal-fetching-for-specific-daos-with-governor-ids)

## Breaking Changes

- No breaking changes - all new methods maintain backward compatibility

## Edge Cases for Reviewer

File path: backend/services/tally_service.py
Line numbers: 1087-1089
Description: The MAX_GOVERNOR_IDS_LIMIT constant is set to 50, which may be too restrictive for some use cases. If users need to fetch proposals from more than 50 governors simultaneously, this will raise an assertion error and block the operation.

Affected code:
```python
MAX_GOVERNOR_IDS_LIMIT = 50

def _validate_governor_ids_params(self, governor_ids: List[str], limit: int) -> None:
    assert len(governor_ids) <= MAX_GOVERNOR_IDS_LIMIT, f"Cannot process more than {MAX_GOVERNOR_IDS_LIMIT} governor IDs at once"
```

Prompt for AI Agent:
```
In backend/services/tally_service.py around line 1089, consider making the MAX_GOVERNOR_IDS_LIMIT configurable or increasing it based on production usage patterns. The current limit of 50 may be too restrictive for autonomous agents that need to monitor many DAOs simultaneously. Consider either making this a configuration setting or implementing batching logic that automatically splits large requests into smaller chunks.
```

File path: backend/services/tally_service.py  
Line numbers: 1245-1250
Description: The semaphore limit for concurrent requests is hardcoded to 5, which may not be optimal for all deployment environments. Different API rate limits or server capacities might require different concurrency settings.

Affected code:
```python
DEFAULT_SEMAPHORE_LIMIT = 5

def __init__(self) -> None:
    self._semaphore = asyncio.Semaphore(DEFAULT_SEMAPHORE_LIMIT)
```

Prompt for AI Agent:
```
In backend/services/tally_service.py around lines 1245-1250, make the semaphore limit configurable through environment variables or settings. The current hardcoded limit of 5 concurrent requests may not be optimal for all environments. Add a configuration option like TALLY_MAX_CONCURRENT_REQUESTS that can be set based on API rate limits and deployment requirements.
```

## Reviewer Test Plan

- [ ] Test single governor ID functionality with get_proposals_by_governor_ids(["single-gov-id"])
- [ ] Test multiple governor IDs with parallel processing get_proposals_by_governor_ids(["gov1", "gov2", "gov3"])
- [ ] Test active proposal filtering with active_only=True parameter
- [ ] Test organization-based fetching with get_proposals_by_organization_governors("org-id")
- [ ] Test deduplication by providing governors that share common proposals
- [ ] Test error resilience by simulating API failures for some governors
- [ ] Test performance limits by attempting to exceed MAX_GOVERNOR_IDS_LIMIT (should fail gracefully)
- [ ] Verify backward compatibility - all existing TallyService functionality still works
- [ ] Test concurrent request limiting by monitoring semaphore behavior
- [ ] Validate that GraphQL requests include proper state filters when active_only=True