### PR TITLE
Fix multisig address checksum in attestation count query

### DIFF
--- a/backend/utils/attestation_tracker_helpers.py
+++ b/backend/utils/attestation_tracker_helpers.py
@@ -56,7 +56,8 @@ def get_multisig_info(multisig_address: str) -> Tuple[int, bool]:
 
         # Query multisig attestation count using available function
         logger.debug(f"Calling getNumAttestations for multisig: {multisig_address}")
-        count = contract.functions.getNumAttestations(multisig_address).call()
+        multisig_checksum_address = Web3.to_checksum_address(multisig_address)
+        count = contract.functions.getNumAttestations(multisig_checksum_address).call()
         logger.info(f"AttestationTracker query successful - multisig={multisig_address}, count={count}")
 
         # Default active status to True since separate active status tracking is not available


### PR DESCRIPTION
## Summary
- Fixes issue with multisig address format when querying attestation count
- Converts multisig address to checksum format before contract call to ensure correctness

## Changes

### Backend Utils
- **attestation_tracker_helpers.py**: Updated `get_multisig_info` function to convert `multisig_address` to checksum address using `Web3.to_checksum_address` before calling `getNumAttestations` on the contract

## Test plan
- [x] Verified that multisig attestation count is correctly retrieved with checksum address
- [x] Confirmed no errors occur due to address format in contract call
- [x] Checked logging output for correct multisig address and count information

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/0fe79288-8ff3-45cf-933b-9fd8134afe1b